### PR TITLE
feat: add GET /api/v1/books/{book_id} endpoint

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,4 +1,5 @@
 from typing import OrderedDict
+from fastapi import APIRouter, status, HTTPException
 
 from fastapi import APIRouter, status
 from fastapi.responses import JSONResponse
@@ -46,6 +47,17 @@ async def create_book(book: Book):
 )
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
+
+# Implement the missing endpoint
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book_by_id(book_id: int) -> Book:
+    book = db.books.get(book_id)
+    if book is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Book not found"
+        )
+    return book
 
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Related Task  
[HNG12 Stage 2 Task](#task-description-link)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbot` as a collaborator.  
