### PR TITLE
fix:updated new PR

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -51,7 +51,7 @@ async def get_books() -> OrderedDict[int, Book]:
 # Implement the missing endpoint
 @router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def get_book_by_id(book_id: int) -> Book:
-    book = db.books.get(book_id).content
+    book = db.books.get(book_id)
     if book is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Related Task  
[HNG12 Stage 2 Task](#task-description-link)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbotops` as a collaborator.  
- Deployment URL: `https://your-app.com/`